### PR TITLE
Fetch recent matches and plot form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created (very simple) Lambda + API Gateway deployment for API [#4](https://github.com/jisantuc/whale-sharks-pool/pull/4)
 - Created frontend skeleton and scripts [#7](https://github.com/jisantuc/whale-sharks-pool/pull/7)
+- Added plots for recent 8 and 9 ball form [#9](https://github.com/jisantuc/whale-sharks-pool/pull/9)
+
+### Changed
+- Fetched recent results instead of all results [#9](https://github.com/jisantuc/whale-sharks-pool/pull/9)

--- a/spago.dhall
+++ b/spago.dhall
@@ -18,6 +18,7 @@ to generate this file without the comments in this block.
   , "argonaut-codecs"
   , "argonaut-core"
   , "argonaut-generic"
+  , "arrays"
   , "bifunctors"
   , "console"
   , "datetime"
@@ -39,6 +40,7 @@ to generate this file without the comments in this block.
   , "spec"
   , "spec-discovery"
   , "strings"
+  , "tuples"
   ]
 , packages = ./packages.dhall
 , sources = [ "src-ps/**/*.purs", "test/**/*.purs" ]

--- a/src-ps/APIClient.purs
+++ b/src-ps/APIClient.purs
@@ -1,0 +1,10 @@
+module APIClient (fetchResults) where
+
+import Affjax (Error)
+import Client (fetchPublicUrl)
+import Data.Either (Either)
+import Effect.Aff (Aff)
+import Model (Results)
+
+fetchResults :: Aff (Either Error Results)
+fetchResults = fetchPublicUrl "https://ec2qa7mfsa.execute-api.us-east-1.amazonaws.com/Production"

--- a/src-ps/AirtableClient.purs
+++ b/src-ps/AirtableClient.purs
@@ -5,20 +5,19 @@ import Affjax (Error(..), printError)
 import Affjax as AX
 import Affjax.RequestHeader (RequestHeader(..))
 import Affjax.ResponseFormat as ResponseFormat
-import Data.Argonaut.Core (Json, stringify)
+import Data.Argonaut.Core (Json)
 import Data.Argonaut.Decode (class DecodeJson, JsonDecodeError, decodeJson, printJsonDecodeError)
 import Data.Bifunctor (lmap)
 import Data.Date (Date)
 import Data.DateTime (date)
 import Data.Either (Either(..))
 import Data.Formatter.DateTime (unformat)
-import Data.String.NonEmpty (unsafeFromString)
 import Effect.Aff (Aff)
-import Model (Game(..), JsonDate(..), Order(..), Result(..), Results, Session(..), WinLoss(..), dateFormat)
+import Model (RawResults, dateFormat)
 import Partial.Unsafe (unsafePartial)
 
-showResult :: forall r. Either Error { body :: Json | r } -> String
-showResult (Right v) = stringify v.body
+showResult :: forall a. Show a => Either Error a -> String
+showResult (Right v) = show v
 
 showResult (Left e) = printError e
 
@@ -51,33 +50,7 @@ getDate (Right d) = d
 exampleDate :: Date
 exampleDate = unsafePartial $ getDate $ date <$> unformat dateFormat "2021-08-27"
 
-mockResults :: Array Result
-mockResults =
-  [ Result
-      { date: JsonDate exampleDate
-      , name: unsafePartial $ unsafeFromString "Jones"
-      , opponentSkill: 4
-      , session: Fall2021
-      , seasonWeek: 1
-      , order: Three
-      , points: 1
-      , winLoss: Loss
-      , game: NineBall
-      }
-  , Result
-      { date: JsonDate exampleDate
-      , name: unsafePartial $ unsafeFromString "Jones"
-      , opponentSkill: 3
-      , session: Fall2021
-      , seasonWeek: 2
-      , order: Two
-      , points: 3
-      , winLoss: Win
-      , game: NineBall
-      }
-  ]
-
-fetchResults :: String -> Aff (Either Error Results)
+fetchResults :: String -> Aff (Either Error RawResults)
 fetchResults token =
   let
     baseUrl = "https://api.airtable.com/v0/app9IJg37UKNWeN8g/Results"

--- a/src-ps/AirtableClient.purs
+++ b/src-ps/AirtableClient.purs
@@ -1,58 +1,21 @@
-module AirtableClient where
+module AirtableClient (recentResults, fetchResults) where
 
-import Prelude
-import Affjax (Error(..), printError)
-import Affjax as AX
-import Affjax.RequestHeader (RequestHeader(..))
-import Affjax.ResponseFormat as ResponseFormat
-import Data.Argonaut.Core (Json)
-import Data.Argonaut.Decode (class DecodeJson, JsonDecodeError, decodeJson, printJsonDecodeError)
-import Data.Bifunctor (lmap)
-import Data.Date (Date)
-import Data.DateTime (date)
-import Data.Either (Either(..))
-import Data.Formatter.DateTime (unformat)
+import Affjax (Error)
+import Client (fetchUrl)
+import Data.Either (Either)
 import Effect.Aff (Aff)
-import Model (RawResults, dateFormat)
-import Partial.Unsafe (unsafePartial)
-
-showResult :: forall a. Show a => Either Error a -> String
-showResult (Right v) = show v
-
-showResult (Left e) = printError e
-
-adaptError :: JsonDecodeError -> Error
-adaptError jsErr =
-  RequestContentError
-    ( "Request failed to produce a meaningful response: " <> printJsonDecodeError jsErr
-    )
-
-getDecodedBody :: forall a. DecodeJson a => AX.Response Json -> Either Error a
-getDecodedBody =
-  lmap adaptError
-    <<< decodeJson
-    <<< _.body
-
-fetchUrl :: forall a. DecodeJson a => String -> String -> Aff (Either Error a)
-fetchUrl token urlString = do
-  result <-
-    AX.request
-      $ AX.defaultRequest
-          { url = urlString
-          , responseFormat = ResponseFormat.json
-          , headers = [ RequestHeader "Authorization" $ "Bearer " <> token ]
-          }
-  pure $ result >>= getDecodedBody
-
-getDate :: Partial => forall e. Either e Date -> Date
-getDate (Right d) = d
-
-exampleDate :: Date
-exampleDate = unsafePartial $ getDate $ date <$> unformat dateFormat "2021-08-27"
+import Model (RawResults)
 
 fetchResults :: String -> Aff (Either Error RawResults)
 fetchResults token =
   let
     baseUrl = "https://api.airtable.com/v0/app9IJg37UKNWeN8g/Results"
+  in
+    fetchUrl token baseUrl
+
+recentResults :: String -> Aff (Either Error RawResults)
+recentResults token =
+  let
+    baseUrl = "https://api.airtable.com/v0/app9IJg37UKNWeN8g/Results?view=Recent"
   in
     fetchUrl token baseUrl

--- a/src-ps/Chart.js
+++ b/src-ps/Chart.js
@@ -2,22 +2,12 @@ const chartJs = require("chart.js");
 
 exports.register = () => chartJs.Chart.register(...chartJs.registerables);
 
-exports.linePlot = (elemId, label, labels, data) => {
-    console.log({
-        label,
-        labels,
-        data
-    });
+exports.linePlot = (elemId, labels, datasets) => {
     return () => new chartJs.Chart(elemId, {
         type: "line",
         data: {
             labels,
-            datasets: [{
-                label,
-                data,
-                backgroundColor: ['rgba(255, 99, 132, 0.2)'],
-                borderWidth: 1
-            }]
+            datasets
         }
     })
 }

--- a/src-ps/Chart.purs
+++ b/src-ps/Chart.purs
@@ -1,13 +1,27 @@
-module Chart (linePlot', register) where
+module Chart (linePlot', register, defaultDataset, Dataset) where
 
 import Prelude
-
-import Data.Function.Uncurried (Fn4, runFn4)
+import Data.Function.Uncurried (Fn3, runFn3)
 import Effect (Effect)
 
 foreign import register :: Effect Unit
 
-foreign import linePlot :: forall a. Fn4 String String a (Array Int) (Effect Unit)
+foreign import linePlot :: forall a. Fn3 String a (Array Dataset) (Effect Unit)
 
-linePlot' :: forall a. String -> String -> a -> Array Int -> Effect Unit
-linePlot' = runFn4 linePlot
+linePlot' :: forall a. String -> a -> Array Dataset -> Effect Unit
+linePlot' = runFn3 linePlot
+
+type Dataset
+  = { label :: String
+    , data :: Array Int
+    , backgroundColor :: Array String
+    , borderWidth :: Int
+    }
+
+defaultDataset :: Dataset
+defaultDataset =
+  { label: "no-data"
+  , data: []
+  , backgroundColor: [ "rgba(255, 99, 132, 0.2)" ]
+  , borderWidth: 1
+  }

--- a/src-ps/Client.purs
+++ b/src-ps/Client.purs
@@ -1,0 +1,45 @@
+module Client (fetchUrl, fetchPublicUrl) where
+
+import Prelude
+import Affjax (Error(..))
+import Affjax as AX
+import Affjax.RequestHeader (RequestHeader(..))
+import Affjax.ResponseFormat as ResponseFormat
+import Data.Argonaut.Core (Json)
+import Data.Argonaut.Decode (class DecodeJson, JsonDecodeError, decodeJson, printJsonDecodeError)
+import Data.Bifunctor (lmap)
+import Data.Either (Either)
+import Effect.Aff (Aff)
+
+adaptError :: JsonDecodeError -> Error
+adaptError jsErr =
+  RequestContentError
+    ( "Request failed to produce a meaningful response: " <> printJsonDecodeError jsErr
+    )
+
+getDecodedBody :: forall a. DecodeJson a => AX.Response Json -> Either Error a
+getDecodedBody =
+  lmap adaptError
+    <<< decodeJson
+    <<< _.body
+
+fetchUrl :: forall a. DecodeJson a => String -> String -> Aff (Either Error a)
+fetchUrl token urlString = do
+  result <-
+    AX.request
+      $ AX.defaultRequest
+          { url = urlString
+          , responseFormat = ResponseFormat.json
+          , headers = [ RequestHeader "Authorization" $ "Bearer " <> token ]
+          }
+  pure $ result >>= getDecodedBody
+
+fetchPublicUrl :: forall a. DecodeJson a => String -> Aff (Either Error a)
+fetchPublicUrl urlString = do
+  result <-
+    AX.request
+      $ AX.defaultRequest
+          { url = urlString
+          , responseFormat = ResponseFormat.json
+          }
+  pure $ result >>= getDecodedBody

--- a/src-ps/Lambda.purs
+++ b/src-ps/Lambda.purs
@@ -1,26 +1,28 @@
 module Lambda (handler) where
 
 import Prelude
+
 import Affjax (printError)
-import AirtableClient (fetchResults)
+import AirtableClient (recentResults)
 import Control.Promise (Promise, fromAff)
 import Data.Argonaut.Core (Json, stringify)
 import Data.Argonaut.Encode (encodeJson)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.Traversable (traverse)
+import Data.Tuple (Tuple(..))
 import Effect.Aff (Aff)
 import Effect.Aff.Compat (EffectFn2, mkEffectFn2)
 import Effect.Class (liftEffect)
 import Effect.Class.Console (error, log)
 import Effect.Exception (throw)
 import Foreign.Object as Object
-import Model (RawResults, Results)
+import Model (RawResults)
 import Node.Process (lookupEnv)
 
 unsafeFetchResults :: String -> Aff RawResults
 unsafeFetchResults token =
-  fetchResults token
+  recentResults token
     >>= case _ of
         Right results -> pure results
         Left e -> error (printError e) *> liftEffect (throw "failed to fetch results")
@@ -36,7 +38,7 @@ mainAff = do
           encodeJson
             { isBase64Encoded: true
             , statusCode: 200
-            , headers: Object.empty :: Object.Object String
+            , headers: Object.fromFoldable [ Tuple "Access-Control-Allow-Origin" "*" ]
             , body: stringify <<< encodeJson $ results
             }
       in

--- a/src-ps/Lambda.purs
+++ b/src-ps/Lambda.purs
@@ -1,7 +1,6 @@
 module Lambda (handler) where
 
 import Prelude
-
 import Affjax (printError)
 import AirtableClient (fetchResults)
 import Control.Promise (Promise, fromAff)
@@ -16,10 +15,10 @@ import Effect.Class (liftEffect)
 import Effect.Class.Console (error, log)
 import Effect.Exception (throw)
 import Foreign.Object as Object
-import Model (Results)
+import Model (RawResults, Results)
 import Node.Process (lookupEnv)
 
-unsafeFetchResults :: String -> Aff Results
+unsafeFetchResults :: String -> Aff RawResults
 unsafeFetchResults token =
   fetchResults token
     >>= case _ of

--- a/src-ps/Model.purs
+++ b/src-ps/Model.purs
@@ -9,7 +9,7 @@ import Data.Bifunctor (lmap)
 import Data.Date (Date, day, month, year)
 import Data.DateTime (DateTime(..), Hour, Millisecond, Minute, Second, Time(..), date)
 import Data.Either (Either(..), note)
-import Data.Enum (toEnum)
+import Data.Enum (fromEnum, toEnum)
 import Data.Formatter.DateTime (Formatter, FormatterCommand(..), format, unformat)
 import Data.Generic.Rep (class Generic)
 import Data.List (List(..), (:))
@@ -19,7 +19,7 @@ import Data.Show.Generic (genericShow)
 import Data.String.NonEmpty (NonEmptyString)
 import Data.Traversable (traverse)
 import Partial.Unsafe (unsafePartial)
-import Prelude (class Show, bind, pure, show, ($), (<$>), (<<<), (<>), (>>=))
+import Prelude (class Eq, class Ord, class Show, bind, pure, show, ($), (<$>), (<<<), (<>), (>>=))
 
 -- models for airtable response like:
 -- |
@@ -63,6 +63,8 @@ instance showWinLoss :: Show WinLoss where
 data Game
   = EightBall
   | NineBall
+
+derive instance Eq Game
 
 instance decodeGame :: DecodeJson Game where
   decodeJson js =
@@ -140,6 +142,10 @@ newtype JsonDate
 
 derive newtype instance showJsonDate :: Show JsonDate
 
+derive newtype instance Eq JsonDate
+
+derive newtype instance Ord JsonDate
+
 dateFormat :: Formatter
 dateFormat =
   YearFull
@@ -155,11 +161,11 @@ jsonDateFromString s = (JsonDate <<< date <$> unformat dateFormat s)
 jsonDateToString :: JsonDate -> String
 jsonDateToString (JsonDate dt) =
   let
-    y = year dt
+    y = fromEnum $ year dt
 
     m = month dt
 
-    d = day dt
+    d = fromEnum $ day dt
   in
     show y <> "-" <> show m <> "-" <> show d
 

--- a/src-ps/UI.purs
+++ b/src-ps/UI.purs
@@ -2,25 +2,81 @@ module UI where
 
 import Prelude
 
-import Chart (linePlot', register)
+import APIClient (fetchResults)
+import Affjax (printError)
+import Chart (Dataset, defaultDataset, linePlot', register)
+import Data.Array as Array
+import Data.Array.NonEmpty (NonEmptyArray, head, toArray)
+import Data.Either (Either(..))
+import Data.String.NonEmpty (toString)
+import Data.Tuple (Tuple(..))
 import Effect (Effect)
+import Effect.Aff (Aff, launchAff_)
+import Effect.Class (liftEffect)
+import Effect.Class.Console (error)
+import Model (Game(..), PlayerName, Result(..), Results(..), jsonDateToString)
 
-chart1 :: Effect Unit
-chart1 = linePlot' "chart1" "Chart 1" ["a", "b", "c", "d", "e"] [1, 2, 3, 4, 5]
+game :: Result -> Game
+game (Result { game: g }) = g
 
-chart2 :: Effect Unit
-chart2 = linePlot' "chart2" "Chart 2" ["j", "k", "l", "m", "n"] [4, 5, 3, 2, 1]
+playerName :: Result -> PlayerName
+playerName (Result { name }) = name
 
-chart3 :: Effect Unit
-chart3 = linePlot' "chart3" "Chart 3" ["a", "b", "c", "d", "e"] [1, 2, 3, 4, 5]
+points :: Result -> Int
+points (Result {points: ps}) = ps
 
-chart4 :: Effect Unit
-chart4 = linePlot' "chart4" "Chart 4" ["j", "k", "l", "m", "n"] [4, 5, 3, 2, 1]
+dateString :: Result -> String
+dateString (Result { date } ) = jsonDateToString date
+
+toDataset :: PlayerName -> NonEmptyArray Result -> Dataset
+toDataset n results = 
+  defaultDataset { data = toArray $ points <$> results
+                 , label = toString n }
+
+toLabels :: Array Result -> Array String
+toLabels results =
+  Array.nub $ dateString <$> Array.sortBy (\(Result { date: date1 }) (Result { date: date2 }) -> compare date1 date2) results
+  
+
+-- chart1 :: Effect Unit
+-- chart1 = linePlot' "chart1" "Chart 1" [ "a", "b", "c", "d", "e" ] [ 1, 2, 3, 4, 5 ]
+
+-- chart2 :: Effect Unit
+-- chart2 = linePlot' "chart2" "Chart 2" [ "j", "k", "l", "m", "n" ] [ 4, 5, 3, 2, 1 ]
+
+-- chart3 :: Effect Unit
+-- chart3 = linePlot' "chart3" "Chart 3" [ "a", "b", "c", "d", "e" ] [ 1, 2, 3, 4, 5 ]
+
+-- chart4 :: Effect Unit
+-- chart4 = linePlot' "chart4" "Chart 4" [ "j", "k", "l", "m", "n" ] [ 4, 5, 3, 2, 1 ]
+
+plotRecentResults :: String -> Results -> (Result -> Boolean) -> Aff Unit
+plotRecentResults elemId (Results d) cond =
+  let
+    grouped :: Array (NonEmptyArray Result)
+    grouped = Array.groupAllBy (\x y -> compare (playerName x) (playerName y)) (Array.filter cond d)
+
+    keyed :: Array (Tuple PlayerName (NonEmptyArray Result))
+    keyed = (\g -> Tuple (playerName $ head g) g) <$> grouped
+
+    datasets :: Array Dataset
+    datasets = (\(Tuple n rs) -> toDataset n rs) <$> keyed
+  in
+    liftEffect $ linePlot' elemId (toLabels d) datasets
+
+plotRecent9BallResults :: Results -> Aff Unit
+plotRecent9BallResults results = plotRecentResults "chart1" results (\r -> game r == NineBall)
+
+plotRecent8BallResults :: Results -> Aff Unit
+plotRecent8BallResults results = plotRecentResults "chart2" results (\r -> game r == EightBall)
 
 main :: Effect Unit
 main = do
   register
-  chart1
-  chart2
-  chart3
-  chart4
+  launchAff_ $ do
+    resp <- fetchResults
+    case resp of
+      Left err -> error $ printError err
+      Right results -> do
+        plotRecent9BallResults results
+        plotRecent8BallResults results

--- a/test/ClientSpec.purs
+++ b/test/ClientSpec.purs
@@ -5,7 +5,7 @@ import Prelude
 import Data.Argonaut.Core (Json)
 import Data.Argonaut.Decode (JsonDecodeError, decodeJson, parseJson)
 import Data.Either (Either, isRight)
-import Model (Results)
+import Model (RawResults, Results)
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldSatisfy)
 
@@ -17,6 +17,6 @@ spec = do
   describe "Decode known results" do
     it "Decodes a single-result known result successfully" $
       let
-        result :: Either JsonDecodeError Results
+        result :: Either JsonDecodeError RawResults
         result = knownResult >>= decodeJson
       in result `shouldSatisfy` isRight

--- a/test/ClientSpec.purs
+++ b/test/ClientSpec.purs
@@ -5,7 +5,7 @@ import Prelude
 import Data.Argonaut.Core (Json)
 import Data.Argonaut.Decode (JsonDecodeError, decodeJson, parseJson)
 import Data.Either (Either, isRight)
-import Model (RawResults, Results)
+import Model (RawResults)
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldSatisfy)
 


### PR DESCRIPTION
## Overview

This PR:

- newtypes `RawResults` so I can separately decode responses from Airtable vs from Lambda and API Gateway
- adds the 8 ball and 9 ball recent result plots (they need some help still but I'll open follow up issues)
- fetches from a "recent results" view instead of all the results

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) (please use [`chan`](https://github.com/geut/chan))

### Demo

![image](https://user-images.githubusercontent.com/5702984/137563573-2335ddec-344b-430a-bab2-82e9404c1e13.png)

Closes #5 

Helps with #3
